### PR TITLE
Fix premature wp_enqueue_scripts call

### DIFF
--- a/wp-content/themes/avada-child/functions.php
+++ b/wp-content/themes/avada-child/functions.php
@@ -20,7 +20,11 @@ if ( function_exists( 'eae_encode_emails' ) )  {
 }
 
 //add wp_enqueue_scripts
-wp_enqueue_script( 'open-children', get_stylesheet_directory_uri() . '/js/open-children.js', array ( 'jquery' ), 1.0, true);
+add_action( 'wp_enqueue_scripts', 'avada_child_enqueue_scripts');
+
+function avada_child_enqueue_scripts() {
+  wp_enqueue_script( 'open-children', get_stylesheet_directory_uri() . '/js/open-children.js', array ( 'jquery' ), 1.0, true);
+}
 
 //add google analytics if not on staging or local Sites
 if (!preg_match_all('#\b(localhost|devsite|stage)\b#', site_url())) {

--- a/wp-content/themes/neve-child/functions.php
+++ b/wp-content/themes/neve-child/functions.php
@@ -20,7 +20,11 @@ if ( function_exists( 'eae_encode_emails' ) )  {
 }
 
 //add wp_enqueue_scripts
-wp_enqueue_script( 'open-children', get_stylesheet_directory_uri() . '/js/open-children.js', array ( 'jquery' ), 1.0, true);
+add_action( 'wp_enqueue_scripts', 'neve_child_enqueue_scripts');
+
+function neve_child_enqueue_scripts() {
+  wp_enqueue_script( 'open-children', get_stylesheet_directory_uri() . '/js/open-children.js', array ( 'jquery' ), 1.0, true);
+}
 
 //add google analytics if not on staging or local Sites
 if (!preg_match_all('#\b(localhost|devsite|stage)\b#', site_url())) {


### PR DESCRIPTION
I set `WP_DEBUG`, `WP_DEBUG_LOG`, and `WP_DEBUG_DISPLAY` all to `true` in my local `wp-config.php` and got this warning:

```
Notice: wp_enqueue_script was called incorrectly. Scripts and styles should not be registered or enqueued until the wp_enqueue_scripts, admin_enqueue_scripts, or login_enqueue_scripts hooks. This notice was triggered by the open-children handle. Please see Debugging in WordPress for more information. (This message was added in version 3.3.0.) in ...../recycleabike/wp-includes/functions.php on line 5225
```

This PR fixes it.